### PR TITLE
[#9] Placeholder service provider

### DIFF
--- a/api/src/main/java/de/minebench/tresor/services/placeholders/Placeholders.java
+++ b/api/src/main/java/de/minebench/tresor/services/placeholders/Placeholders.java
@@ -1,0 +1,31 @@
+package de.minebench.tresor.services.placeholders;
+
+/*
+ * Tresor - Abstraction library for Bukkit plugins Copyright (C) 2024 Max Lee aka Phoenix616
+ * (max@themoep.de) Copyright (C) 2024 Tresor Contributors
+ * (https://github.com/Minebench/Tresor/graphs/contributors)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tresor. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+
+import de.minebench.tresor.services.TresorServiceProvider;
+
+/**
+ * The Placeholders service API for managing {@link TresorPlaceholderExpansion}s
+ * 
+ */
+public interface Placeholders extends TresorServiceProvider {
+
+    boolean registerTresorPlaceholderExpansion(TresorPlaceholderExpansion placeholderExpansion);
+
+}

--- a/api/src/main/java/de/minebench/tresor/services/placeholders/TresorPlaceholderExpansion.java
+++ b/api/src/main/java/de/minebench/tresor/services/placeholders/TresorPlaceholderExpansion.java
@@ -1,0 +1,62 @@
+package de.minebench.tresor.services.placeholders;
+
+/*
+ * Tresor - Abstraction library for Bukkit plugins Copyright (C) 2024 Max Lee aka Phoenix616
+ * (max@themoep.de) Copyright (C) 2024 Tresor Contributors
+ * (https://github.com/Minebench/Tresor/graphs/contributors)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tresor. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+
+import org.bukkit.OfflinePlayer;
+
+/**
+ * The TresorPlaceholderExpansion class contains basic info about a plugins placeholders and a
+ * method, onRequest, for developers to override with their placeholder implementations
+ * 
+ * *This class is obviously very largely from PlaceholderAPI's implementation
+ */
+public interface TresorPlaceholderExpansion {
+
+
+    /**
+     * An identifier so that all placeholders with this identifier are directed to this particular
+     * implementation
+     */
+    public String getIdentifier();
+
+    /**
+     * The name of the plugin which this placeholder is dependent on to be able to function
+     */
+    public String getRequiredPlugin();
+
+    public String getAuthor();
+
+    public String getVersion();
+
+    /**
+     * 
+     * @return Whether the requiredPlugin is present
+     */
+    public boolean canPlaceholderRegister();
+
+    /**
+     * Processes the params received for the specified player, returns the translated placeholder
+     * 
+     * @param player OfflinePlayer to translate params for
+     * @param params The placeholder request without the identifier
+     * @return Translated string
+     */
+    public abstract String onRequest(OfflinePlayer player, String params);
+
+}

--- a/plugin/src/main/java/de/minebench/tresor/Tresor.java
+++ b/plugin/src/main/java/de/minebench/tresor/Tresor.java
@@ -24,6 +24,7 @@ import com.google.common.collect.MultimapBuilder;
 import de.minebench.tresor.services.authentication.Authentication;
 import de.minebench.tresor.services.economy.ModernEconomy;
 import de.minebench.tresor.services.hologram.Holograms;
+import de.minebench.tresor.services.placeholders.Placeholders;
 import de.themoep.hook.bukkit.HookManager;
 import net.milkbowl.vault.chat.Chat;
 import net.milkbowl.vault.economy.Economy;
@@ -78,6 +79,7 @@ public class Tresor extends JavaPlugin implements TresorAPI {
         new ProviderManager(ModernEconomy.class);
         new ProviderManager(Permission.class);
         new ProviderManager(Chat.class);
+        new ProviderManager(Placeholders.class);
     }
 
     @Override

--- a/providers/placeholderapi/pom.xml
+++ b/providers/placeholderapi/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>de.minebench.tresor.providers</groupId>
+    <artifactId>placeholderapi</artifactId>
+
+    <parent>
+        <groupId>de.minebench.tresor</groupId>
+        <artifactId>tresor-providers</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <repositories>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+         <groupId>me.clip</groupId>
+          <artifactId>placeholderapi</artifactId>
+          <version>2.11.6</version>
+         <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/providers/placeholderapi/src/main/java/de/minebench/tresor/providers/placeholderapi/PlaceholderApiExpansionWrapper.java
+++ b/providers/placeholderapi/src/main/java/de/minebench/tresor/providers/placeholderapi/PlaceholderApiExpansionWrapper.java
@@ -1,0 +1,63 @@
+package de.minebench.tresor.providers.placeholderapi;
+
+/*
+ * Tresor - Abstraction library for Bukkit plugins
+ * Copyright (C) 2024 Max Lee aka Phoenix616 (max@themoep.de)
+ * Copyright (C) 2024 Tresor Contributors (https://github.com/Minebench/Tresor/graphs/contributors)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tresor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+import org.bukkit.OfflinePlayer;
+
+import de.minebench.tresor.services.placeholders.TresorPlaceholderExpansion;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+public class PlaceholderApiExpansionWrapper extends PlaceholderExpansion {
+
+    private TresorPlaceholderExpansion TresorPlaceholderExpansion;
+
+    public PlaceholderApiExpansionWrapper(TresorPlaceholderExpansion TresorPlaceholderExpansion) throws NullPointerException {
+        if(TresorPlaceholderExpansion == null) {
+            throw new NullPointerException("Cannot construct PlaceholderApiExpansionWrapper from null TresorPlaceholderExpansion");
+        }
+        this.TresorPlaceholderExpansion = TresorPlaceholderExpansion;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return TresorPlaceholderExpansion.getIdentifier();
+    }
+
+    @Override
+    public String getAuthor() {
+        return TresorPlaceholderExpansion.getAuthor();
+    }
+
+    @Override
+    public String getRequiredPlugin() {
+        return TresorPlaceholderExpansion.getRequiredPlugin();
+    }
+
+    @Override
+    public String getVersion() {
+        return TresorPlaceholderExpansion.getVersion();
+    }
+    
+    @Override
+    public String onRequest(OfflinePlayer player, String params) {
+        return TresorPlaceholderExpansion.onRequest(player, params);
+    }
+
+}

--- a/providers/placeholderapi/src/main/java/de/minebench/tresor/providers/placeholderapi/PlaceholderApiPlaceholders.java
+++ b/providers/placeholderapi/src/main/java/de/minebench/tresor/providers/placeholderapi/PlaceholderApiPlaceholders.java
@@ -1,0 +1,72 @@
+package de.minebench.tresor.providers.placeholderapi;
+
+/*
+ * Tresor - Abstraction library for Bukkit plugins
+ * Copyright (C) 2024 Max Lee aka Phoenix616 (max@themoep.de)
+ * Copyright (C) 2024 Tresor Contributors (https://github.com/Minebench/Tresor/graphs/contributors)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tresor.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+import org.bukkit.Bukkit;
+
+import de.minebench.tresor.Provider;
+import de.minebench.tresor.services.placeholders.Placeholders;
+import de.minebench.tresor.services.placeholders.TresorPlaceholderExpansion;
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
+
+public class PlaceholderApiPlaceholders extends Provider<Placeholders, PlaceholderAPIPlugin> implements Placeholders {
+
+    private PlaceholderAPIPlugin hooked;
+
+    public PlaceholderApiPlaceholders() {
+        super(Placeholders.class);
+    }
+
+    /*
+     * Tresor Hook related methods
+     */
+
+     @Override
+    public boolean isEnabled() {
+        return getHooked() != null ? hooked.isEnabled() : Bukkit.getServer().getPluginManager().isPluginEnabled(getName());
+    }
+
+    @Override
+    public PlaceholderAPIPlugin getHooked() {
+        if (hooked == null) {
+            hooked = (PlaceholderAPIPlugin) Bukkit.getServer().getPluginManager().getPlugin(getName());
+        }
+        return hooked;
+    }
+    
+    @Override
+    public String getName() {
+        return "PlaceholderAPI";
+    }
+
+    /*
+     * Placeholder Expansion related methods
+     */
+
+    @Override
+    public boolean registerTresorPlaceholderExpansion(TresorPlaceholderExpansion placeholderExpansion) {
+        PlaceholderApiExpansionWrapper expansionWrapper = new PlaceholderApiExpansionWrapper(placeholderExpansion);
+        return expansionWrapper.register();
+    }
+
+
+
+}


### PR DESCRIPTION
Hi,

#9 - Apologies I didn't see another PR had been raised for this already & don't intend to create a 'race' of any sorts - I'm not looking for the IssueHunt.

I've implemented a very rough approach and just implemented an abstraction layer directly for PlaceholderApi and maintained PlaceholderApi's approach of leaving the translation of 'params' completely up to the external implementation, rather than looking to create a mapping within Tresor, though I appreciate this may not be what was in mind?

The end-goal in my head is that when adding other Providers in the future, a translation can be created between PAPI's format and their format. 
Though I'm not aware of other providers / Placeholder plugins, I had a brief look at MVDW but it appeared that it's exclusively for MVDW's premium plugins and are all available via PAPI regardless?

* Currently untested code

Let me know, I'm quite keen to contribute to some open source repos and this seemed like a good issue to pick up but if I've missed the intended mark I'm happy to adjust this or look at another issue (given the other PR raised for #9 too).